### PR TITLE
Fix simulation defaults

### DIFF
--- a/components/scenario-creator.tsx
+++ b/components/scenario-creator.tsx
@@ -9,7 +9,14 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { CompanyForm } from "@/components/company-form"
-import { type Scenario, type Company, CompanySize, Territory, IncentiveType } from "@/lib/types"
+import {
+  type Scenario,
+  type Company,
+  CompanySize,
+  Territory,
+  IncentiveType,
+} from "@/lib/types"
+import { DEFAULT_PARAMETERS } from "@/lib/simulation-engine"
 
 interface ScenarioCreatorProps {
   onAddScenario: (scenario: Scenario) => void
@@ -29,6 +36,7 @@ const scenarioTemplates = [
         incentiveTypes: [IncentiveType.IDI],
       },
     ],
+    parameters: DEFAULT_PARAMETERS,
   },
   {
     name: "Multiple SMEs",
@@ -58,6 +66,7 @@ const scenarioTemplates = [
         incentiveTypes: [IncentiveType.IDT, IncentiveType.IP],
       },
     ],
+    parameters: DEFAULT_PARAMETERS,
   },
 ]
 
@@ -118,6 +127,7 @@ export function ScenarioCreator({ onAddScenario }: ScenarioCreatorProps) {
       name,
       createdAt: new Date().toISOString(),
       companies,
+      parameters: DEFAULT_PARAMETERS,
     }
 
     onAddScenario(newScenario)

--- a/lib/simulation-engine.ts
+++ b/lib/simulation-engine.ts
@@ -1,14 +1,31 @@
 import { v4 as uuidv4 } from "uuid"
-import type { Scenario, SimulationResult, TimeSeriesPoint } from "./types"
+import type {
+  Scenario,
+  SimulationResult,
+  TimeSeriesPoint,
+  SimulationParameters,
+} from "./types"
+
+export const DEFAULT_PARAMETERS: SimulationParameters = {
+  population: { value: 1000 },
+  growthRate: { value: 0.02 },
+  volatility: { value: 0.1 },
+  enableRandomEvents: { value: true },
+  iterations: { value: 50 },
+}
 
 // Simulates population growth based on scenario parameters
-export async function runSimulation(scenario: Scenario): Promise<SimulationResult> {
+export async function runSimulation(
+  scenario: Scenario,
+): Promise<SimulationResult> {
+  const params = scenario.parameters ?? DEFAULT_PARAMETERS
+
   // Extract parameters
-  const initialPopulation = scenario.parameters.population.value as number
-  const growthRate = scenario.parameters.growthRate.value as number
-  const volatility = scenario.parameters.volatility.value as number
-  const enableRandomEvents = scenario.parameters.enableRandomEvents.value as boolean
-  const iterations = scenario.parameters.iterations.value as number
+  const initialPopulation = params.population.value
+  const growthRate = params.growthRate.value
+  const volatility = params.volatility.value
+  const enableRandomEvents = params.enableRandomEvents.value
+  const iterations = params.iterations.value
 
   // Initialize time series data
   const timeSeriesData: TimeSeriesPoint[] = []

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,11 +26,20 @@ export interface Company {
   incentiveTypes: IncentiveType[]
 }
 
+export interface SimulationParameters {
+  population: { value: number }
+  growthRate: { value: number }
+  volatility: { value: number }
+  enableRandomEvents: { value: boolean }
+  iterations: { value: number }
+}
+
 export interface Scenario {
   id: string
   name: string
   createdAt: string
   companies: Company[]
+  parameters?: SimulationParameters
 }
 
 export interface TimeSeriesPoint {


### PR DESCRIPTION
## Summary
- support optional simulation parameters in type definitions
- provide defaults in simulation engine
- ensure new scenarios include default parameters

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca13eea4832d9684112b3f157ef1